### PR TITLE
Cache metamethods, finalize references

### DIFF
--- a/Eluant/LuaClrObjectValue.cs
+++ b/Eluant/LuaClrObjectValue.cs
@@ -1,10 +1,12 @@
 //
 // LuaClrObjectValue.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +27,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
+using Eluant.ObjectBinding;
 
 namespace Eluant
 {
@@ -53,6 +57,15 @@ namespace Eluant
         }
 
         internal abstract object BackingCustomObject { get; }
+
+        internal abstract MetamethodAttribute[] BackingCustomObjectMetamethods { get; }
+
+        static internal MetamethodAttribute[] Metamethods(Type backingCustomObjectType)
+        {
+            return backingCustomObjectType.GetInterfaces()
+                .SelectMany(iface => iface.GetCustomAttributes(typeof(MetamethodAttribute), false).Cast<MetamethodAttribute>())
+                .ToArray();
+        }
 
         internal override object ToClrType(Type type)
         {

--- a/Eluant/LuaCustomClrObject.cs
+++ b/Eluant/LuaCustomClrObject.cs
@@ -1,10 +1,12 @@
 //
 // LuaCustomClrObject.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +27,7 @@
 // THE SOFTWARE.
 
 using System;
+using Eluant.ObjectBinding;
 
 namespace Eluant
 {
@@ -50,6 +53,13 @@ namespace Eluant
         internal override object BackingCustomObject
         {
             get { return ClrObject; }
+        }
+
+        private MetamethodAttribute[] metamethods;
+
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        {
+            get { return metamethods ?? (metamethods = Metamethods(BackingCustomObject.GetType())); }
         }
     }
 }

--- a/Eluant/LuaOpaqueClrObject.cs
+++ b/Eluant/LuaOpaqueClrObject.cs
@@ -1,10 +1,12 @@
 //
 // LuaOpaqueClrObject.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +27,7 @@
 // THE SOFTWARE.
 
 using System;
+using Eluant.ObjectBinding;
 
 namespace Eluant
 {
@@ -48,6 +51,11 @@ namespace Eluant
         }
 
         internal override object BackingCustomObject
+        {
+            get { return null; }
+        }
+
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
         {
             get { return null; }
         }

--- a/Eluant/LuaReference.cs
+++ b/Eluant/LuaReference.cs
@@ -1,10 +1,12 @@
 //
 // LuaReference.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +52,7 @@ namespace Eluant
         public sealed override void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Eluant/LuaRuntime.cs
+++ b/Eluant/LuaRuntime.cs
@@ -1,10 +1,12 @@
 //
 // LuaRuntime.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -776,10 +778,7 @@ namespace Eluant
                 LuaApi.lua_settable(LuaState, -3);
 
                 // For all others, we use MetamethodAttribute on the interface to make this code less repetitive.
-                var metamethods = obj.BackingCustomObject.GetType().GetInterfaces()
-                    .SelectMany(iface => iface.GetCustomAttributes(typeof(MetamethodAttribute), false).Cast<MetamethodAttribute>());
-
-                foreach (var metamethod in metamethods) {
+                foreach (var metamethod in obj.BackingCustomObjectMetamethods) {
                     LuaApi.lua_pushstring(LuaState, metamethod.MethodName);
                     Push(metamethodCallbacks[metamethod.MethodName]);
                     LuaApi.lua_settable(LuaState, -3);

--- a/Eluant/LuaTransparentClrObject.cs
+++ b/Eluant/LuaTransparentClrObject.cs
@@ -1,10 +1,12 @@
 //
 // LuaTransparentClrObject.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -71,8 +73,15 @@ namespace Eluant
             get { return proxy; }
         }
 
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        {
+            get { return TransparentClrObjectProxy.Metamethods; }
+        }
+
         private class TransparentClrObjectProxy : ILuaTableBinding, ILuaEqualityBinding
         {
+            public static readonly MetamethodAttribute[] Metamethods = LuaClrObjectValue.Metamethods(typeof(TransparentClrObjectProxy));
+
             private LuaTransparentClrObject clrObject;
 
             public TransparentClrObjectProxy(LuaTransparentClrObject obj)


### PR DESCRIPTION
This improves performance in two ways:
- We cache the reflection needed when making calls involving a `LuaCustomClrObject`. If a caller reuses the same object in multiple calls, they now only invoke the reflection overhead on the first call. A call involving any `LuaTransparentClrObject` benefits even more as we can cache this once for the whole app-domain.
- We add a missing `GC.SuppressFinalize` call to `LuaReference`. Callers that take care to dispose these properly can now avoid finalizing these objects.

Fixes OpenRA/OpenRA#9142
