### PR TITLE
Cache metamethods in each LuaRuntime.

### DIFF
--- a/Eluant/LuaClrObjectValue.cs
+++ b/Eluant/LuaClrObjectValue.cs
@@ -58,7 +58,7 @@ namespace Eluant
 
         internal abstract object BackingCustomObject { get; }
 
-        internal abstract MetamethodAttribute[] BackingCustomObjectMetamethods { get; }
+        internal abstract MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime);
 
         static internal MetamethodAttribute[] Metamethods(Type backingCustomObjectType)
         {

--- a/Eluant/LuaCustomClrObject.cs
+++ b/Eluant/LuaCustomClrObject.cs
@@ -57,9 +57,9 @@ namespace Eluant
 
         private MetamethodAttribute[] metamethods;
 
-        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime)
         {
-            get { return metamethods ?? (metamethods = Metamethods(BackingCustomObject.GetType())); }
+            return metamethods ?? (metamethods = runtime.CachedMetamethods(BackingCustomObject.GetType()));
         }
     }
 }

--- a/Eluant/LuaOpaqueClrObject.cs
+++ b/Eluant/LuaOpaqueClrObject.cs
@@ -55,9 +55,9 @@ namespace Eluant
             get { return null; }
         }
 
-        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime)
         {
-            get { return null; }
+            return null;
         }
     }
 }

--- a/Eluant/LuaTransparentClrObject.cs
+++ b/Eluant/LuaTransparentClrObject.cs
@@ -73,9 +73,9 @@ namespace Eluant
             get { return proxy; }
         }
 
-        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime)
         {
-            get { return TransparentClrObjectProxy.Metamethods; }
+            return TransparentClrObjectProxy.Metamethods;
         }
 
         private class TransparentClrObjectProxy : ILuaTableBinding, ILuaEqualityBinding


### PR DESCRIPTION
This reflection is expensive, so by allowing it to be cached against each runtime we can remove most of the cost. Since each runtime is likely to only deal with a handful of custom objects, it shouldn't be an issue for memory usage.

---

On the RA shellmap, this reduces time spent in Lua from 3.3 to 2.4% of total CPU.
