### PR TITLE
Downgraded Ubuntu VS version for Windows the build

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
     windows:
         name: Windows (x86 + x64)
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-20.04
         steps:
             - name: Setup Dependencies
               run: |


### PR DESCRIPTION
For whatever reason compiling Windows native binaries on Ubuntu 22.04 produces a 32-bit binary that doesn't work (the 64-bit one does work). Compiling them on Ubuntu 20.04 produces working binaries, which are also both much smaller than the ones from Ubuntu 22.04.

This is obviously not the optimal solution, but is a simple fix that we can get in quickly for an ORA release until someone has the time to investigate relevant Ubuntu packages and how they change between 20.04 and 22.04.